### PR TITLE
Cache the Go build cache during CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,17 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
+      - name: Find the Go build Cache
+        id: go
+        run: echo "::set-output name=cache::$(go env GOCACHE)"
+
+      - name: Cache the Go build Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.go.outputs.cache }}
+          key: ${{ runner.os }}-build-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-build-
+
       - name: Cache Go Dependencies
         uses: actions/cache@v2
         with:
@@ -112,6 +123,17 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GO_VERSION }}
+
+      - name: Find the Go build Cache
+        id: go
+        run: echo "::set-output name=cache::$(go env GOCACHE)"
+
+      - name: Cache the Go build Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.go.outputs.cache }}
+          key: ${{ runner.os }}-build-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-build-
 
       - name: Cache Go Dependencies
         uses: actions/cache@v2
@@ -161,6 +183,17 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GO_VERSION }}
+
+      - name: Find the Go build Cache
+        id: go
+        run: echo "::set-output name=cache::$(go env GOCACHE)"
+
+      - name: Cache the Go build Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.go.outputs.cache }}
+          key: ${{ runner.os }}-build-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-build-
 
       - name: Cache Go Dependencies
         uses: actions/cache@v2
@@ -212,6 +245,17 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GO_VERSION }}
+
+      - name: Find the Go build Cache
+        id: go
+        run: echo "::set-output name=cache::$(go env GOCACHE)"
+
+      - name: Cache the Go build Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.go.outputs.cache }}
+          key: ${{ runner.os }}-build-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-build-
 
       - name: Cache Go Dependencies
         uses: actions/cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,12 @@ jobs:
     steps:
       - name: Detect No-op Changes
         id: noop
-        uses: fkirc/skip-duplicate-actions@v2.0.0
+        uses: fkirc/skip-duplicate-actions@v2.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           paths_ignore: '["**.md", "**.png", "**.jpg"]'
           do_not_skip: '["workflow_dispatch", "schedule", "push"]'
+          concurrent_skipping: false
 
 
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,4 +314,6 @@ jobs:
           CHANNEL: master
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_USR }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PSW }}
+          DOCS_GIT_USR: ${{ secrets.UPBOUND_BOT_GITHUB_USR }}
+          DOCS_GIT_PSW: ${{ secrets.UPBOUND_BOT_GITHUB_PSW }}
         

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,20 +284,20 @@ jobs:
           # We're using docker buildx, which doesn't actually load the images it
           # builds by default. Specifying --load does so.
           BUILD_ARGS: "--load"
-      
+
       - name: Publish Artifacts to GitHub
         uses: actions/upload-artifact@v2
         with:
           name: output
           path: _output/**
-      
+
       - name: Login to Docker
         uses: docker/login-action@v1
         if: env.DOCKER_USR != ''
         with:
           username: ${{ secrets.DOCKER_USR }}
           password: ${{ secrets.DOCKER_PSW }}
-      
+
       - name: Publish Artifacts to S3 and Docker Hub
         run: make -j2 publish BRANCH_NAME=${GITHUB_REF##*/}
         if: env.AWS_USR != '' && env.DOCKER_USR != ''
@@ -305,7 +305,9 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_USR }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PSW }}
           GIT_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
+          DOCS_GIT_USR: ${{ secrets.UPBOUND_BOT_GITHUB_USR }}
+          DOCS_GIT_PSW: ${{ secrets.UPBOUND_BOT_GITHUB_PSW }}
+
       - name: Promote Artifacts in S3 and Docker Hub
         if: github.ref == 'refs/heads/master' && env.AWS_USR != '' && env.DOCKER_USR != ''
         run: make -j2 promote
@@ -314,6 +316,3 @@ jobs:
           CHANNEL: master
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_USR }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PSW }}
-          DOCS_GIT_USR: ${{ secrets.UPBOUND_BOT_GITHUB_USR }}
-          DOCS_GIT_PSW: ${{ secrets.UPBOUND_BOT_GITHUB_PSW }}
-        

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,17 @@ jobs:
         with:
           submodules: true
 
+      - name: Find the Go Build Cache
+        id: go
+        run: echo "::set-output name=cache::$(go env GOCACHE)"
+
+      - name: Cache the Go Build Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.go.outputs.cache }}
+          key: ${{ runner.os }}-build-lint-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-build-lint-
+
       - name: Cache Go Dependencies
         uses: actions/cache@v2
         with:
@@ -81,16 +92,16 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - name: Find the Go build Cache
+      - name: Find the Go Build Cache
         id: go
         run: echo "::set-output name=cache::$(go env GOCACHE)"
 
-      - name: Cache the Go build Cache
+      - name: Cache the Go Build Cache
         uses: actions/cache@v2
         with:
           path: ${{ steps.go.outputs.cache }}
-          key: ${{ runner.os }}-build-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-build-
+          key: ${{ runner.os }}-build-check-diff-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-build-check-diff-
 
       - name: Cache Go Dependencies
         uses: actions/cache@v2
@@ -124,16 +135,16 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - name: Find the Go build Cache
+      - name: Find the Go Build Cache
         id: go
         run: echo "::set-output name=cache::$(go env GOCACHE)"
 
-      - name: Cache the Go build Cache
+      - name: Cache the Go Build Cache
         uses: actions/cache@v2
         with:
           path: ${{ steps.go.outputs.cache }}
-          key: ${{ runner.os }}-build-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-build-
+          key: ${{ runner.os }}-build-unit-tests-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-build-unit-tests-
 
       - name: Cache Go Dependencies
         uses: actions/cache@v2
@@ -184,16 +195,16 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - name: Find the Go build Cache
+      - name: Find the Go Build Cache
         id: go
         run: echo "::set-output name=cache::$(go env GOCACHE)"
 
-      - name: Cache the Go build Cache
+      - name: Cache the Go Build Cache
         uses: actions/cache@v2
         with:
           path: ${{ steps.go.outputs.cache }}
-          key: ${{ runner.os }}-build-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-build-
+          key: ${{ runner.os }}-build-e2e-tests-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-build-e2e-tests-
 
       - name: Cache Go Dependencies
         uses: actions/cache@v2
@@ -246,16 +257,16 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - name: Find the Go build Cache
+      - name: Find the Go Build Cache
         id: go
         run: echo "::set-output name=cache::$(go env GOCACHE)"
 
-      - name: Cache the Go build Cache
+      - name: Cache the Go Build Cache
         uses: actions/cache@v2
         with:
           path: ${{ steps.go.outputs.cache }}
-          key: ${{ runner.os }}-build-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-build-
+          key: ${{ runner.os }}-build-publish-artifacts-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-build-publish-artifacts-
 
       - name: Cache Go Dependencies
         uses: actions/cache@v2

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -31,6 +31,13 @@ jobs:
       - name: Fetch History
         run: git fetch --prune --unshallow
 
+      - name: Login to Docker
+        uses: docker/login-action@v1
+        if: env.DOCKER_USR != ''
+        with:
+          username: ${{ secrets.DOCKER_USR }}
+          password: ${{ secrets.DOCKER_PSW }}
+
       - name: Promote Artifacts in S3 and Docker Hub
         if: env.AWS_USR != '' && env.DOCKER_USR != ''
         run: make -j2 promote BRANCH_NAME=${GITHUB_REF##*/}

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -46,6 +46,3 @@ jobs:
           CHANNEL: ${{ github.event.inputs.channel }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_USR }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PSW }}
-          DOCS_GIT_USR: ${{ secrets.UPBOUND_BOT_GITHUB_USR }}
-          DOCS_GIT_PSW: ${{ secrets.UPBOUND_BOT_GITHUB_PSW }}
-        

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -46,4 +46,6 @@ jobs:
           CHANNEL: ${{ github.event.inputs.channel }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_USR }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PSW }}
+          DOCS_GIT_USR: ${{ secrets.UPBOUND_BOT_GITHUB_USR }}
+          DOCS_GIT_PSW: ${{ secrets.UPBOUND_BOT_GITHUB_PSW }}
         

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -6,6 +6,9 @@ on:
       version:
         description: 'Release version (e.g. v0.1.0)'
         required: true
+      message:
+        description: 'Tag message'
+        required: true
 
 jobs:
   create-tag:
@@ -14,14 +17,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          submodules: true
-
-      - name: Fetch History
-        run: git fetch --prune --unshallow
 
       - name: Create Tag
-        run: make -j2 tag
-        env:
-          VERSION: ${{ github.event.inputs.version }}
-        
+        uses: negz/create-tag@v1
+        with:
+          version: ${{ github.event.inputs.version }}
+          message: ${{ github.event.inputs.message }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ IMAGES = crossplane
 
 SOURCE_DOCS_DIR = docs
 DEST_DOCS_DIR = docs
-DOCS_GIT_REPO = https://$(GIT_API_TOKEN)@github.com/crossplane/crossplane.github.io.git
+DOCS_GIT_REPO = https://$(DOCS_GIT_USR):$(DOCS_GIT_PSW)@github.com/crossplane/crossplane.github.io.git
 -include build/makelib/docs.mk
 
 # ====================================================================================

--- a/cluster/charts/crossplane/templates/provider.yaml
+++ b/cluster/charts/crossplane/templates/provider.yaml
@@ -3,7 +3,7 @@
 apiVersion: pkg.crossplane.io/v1alpha1
 kind: Provider
 metadata:
-  name: {{ . | trim | replace "/" "-" | replace ":" "-" }}
+  name: {{ regexReplaceAll "(:|@).*" . "" | trim | replace "/" "-" }}
 spec:
   package: {{ . | trim }}
 ---

--- a/docs/introduction/managed-resources.md
+++ b/docs/introduction/managed-resources.md
@@ -235,7 +235,7 @@ apiVersion: compute.gcp.crossplane.io/v1beta1
 kind: Network
 metadata:
   name: foo-network
-  annotation:
+  annotations:
     crossplane.io/external-name: existing-network
 spec:
   providerConfigRef:

--- a/pkg/xpkg/name.go
+++ b/pkg/xpkg/name.go
@@ -54,7 +54,8 @@ func truncate(str string, num int) string {
 // FriendlyID builds a maximum 63 character string made up of the name of a
 // package and its image digest.
 func FriendlyID(name, hash string) string {
-	return strings.Join([]string{truncate(name, 50), truncate(hash, 12)}, "-")
+	id := strings.ReplaceAll(strings.Join([]string{truncate(name, 50), truncate(hash, 12)}, "-"), ".", "-")
+	return id
 }
 
 // BuildPath builds a path for a compiled Crossplane package. If file name has

--- a/pkg/xpkg/name.go
+++ b/pkg/xpkg/name.go
@@ -52,7 +52,8 @@ func truncate(str string, num int) string {
 }
 
 // FriendlyID builds a maximum 63 character string made up of the name of a
-// package and its image digest.
+// package and its image digest. It expects the first string to be a valid DNS
+// subdomain name and the second to be a valid OCI image digest.
 func FriendlyID(name, hash string) string {
 	id := strings.ReplaceAll(strings.Join([]string{truncate(name, 50), truncate(hash, 12)}, "-"), ".", "-")
 	return id

--- a/pkg/xpkg/name_test.go
+++ b/pkg/xpkg/name_test.go
@@ -65,6 +65,14 @@ func TestFriendlyID(t *testing.T) {
 			},
 			want: "provider-aws-plusabunchofothernonsensethatisgoingt-123456789123",
 		},
+		"ReplacePeriod": {
+			reason: "All period characters should be replaced with a dash.",
+			args: args{
+				pkg:  "provider.aws-plusabunchofothernonsensethatisgoingtogetslicedoff",
+				hash: "1234.567891234567",
+			},
+			want: "provider-aws-plusabunchofothernonsensethatisgoingt-1234-5678912",
+		},
 	}
 
 	for name, tc := range cases {


### PR DESCRIPTION
This should speed up runs in which no dependencies have changed.
